### PR TITLE
Use proper path types

### DIFF
--- a/examples/daily_file/src/main.rs
+++ b/examples/daily_file/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use ftail::Ftail;
 use log::LevelFilter;
 
@@ -6,7 +8,7 @@ use log::LevelFilter;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ftail::new()
         .retention_days(14)
-        .daily_file("logs", LevelFilter::Trace)
+        .daily_file(Path::new("logs"), LevelFilter::Trace)
         .init()?;
 
     log::trace!("This is a trace message");

--- a/examples/single_file/src/main.rs
+++ b/examples/single_file/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use ftail::Ftail;
 use log::LevelFilter;
 
@@ -5,7 +7,7 @@ use log::LevelFilter;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ftail::new()
-        .single_file("logs/demo.log", true, LevelFilter::Trace)
+        .single_file(Path::new("logs/demo.log"), true, LevelFilter::Trace)
         .max_file_size(10)
         .init()?;
 

--- a/examples/stack/src/main.rs
+++ b/examples/stack/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use ftail::Ftail;
 use log::LevelFilter;
 
@@ -6,8 +8,8 @@ use log::LevelFilter;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ftail::new()
         .console(LevelFilter::Info)
-        .single_file("logs/trace.log", true, LevelFilter::Trace)
-        .single_file("logs/error.log", true, LevelFilter::Error)
+        .single_file(Path::new("logs/trace.log"), true, LevelFilter::Trace)
+        .single_file(Path::new("logs/error.log"), true, LevelFilter::Error)
         .init()?;
 
     log::trace!("This is a trace message");

--- a/src/channels/daily_file.rs
+++ b/src/channels/daily_file.rs
@@ -2,7 +2,7 @@ use log::{LevelFilter, Log};
 use std::{
     fs::File,
     io::{LineWriter, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Mutex,
 };
 
@@ -17,15 +17,15 @@ use crate::{
 pub struct DailyFileLogger {
     file: Mutex<LineWriter<File>>,
     file_path: PathBuf,
-    dir: String,
+    dir: PathBuf,
     current_date: Mutex<String>,
     config: Config,
 }
 
 impl DailyFileLogger {
-    pub fn new(dir: &str, config: Config) -> Result<Self, FtailError> {
-        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-        let path = format!("{}/{}.log", dir, today);
+    pub fn new(dir: &Path, config: Config) -> Result<Self, FtailError> {
+        let today_filename = chrono::Local::now().format("%Y-%m-%d.log").to_string();
+        let path = dir.join(&today_filename);
 
         let file = std::fs::OpenOptions::new()
             .create(true)
@@ -36,14 +36,14 @@ impl DailyFileLogger {
         let md = std::fs::metadata(dir).map_err(FtailError::IoError)?;
 
         if md.permissions().readonly() {
-            return Err(FtailError::PermissionsError(dir.to_string()));
+            return Err(FtailError::PermissionsError(dir.to_owned()));
         }
 
         Ok(DailyFileLogger {
             file: Mutex::new(LineWriter::new(file)),
-            file_path: PathBuf::from(path),
-            dir: dir.to_string(),
-            current_date: Mutex::new(today),
+            file_path: path,
+            dir: dir.to_owned(),
+            current_date: Mutex::new(today_filename),
             config,
         })
     }
@@ -53,7 +53,7 @@ impl DailyFileLogger {
         let mut current_date = self.current_date.lock().unwrap();
 
         if *current_date != today {
-            let path = format!("{}/{}.log", self.dir, today);
+            let path = self.dir.join(format!("{today}.log"));
 
             let new_file = std::fs::OpenOptions::new()
                 .create(true)
@@ -102,7 +102,7 @@ impl Log for DailyFileLogger {
     }
 }
 
-fn remove_old_log_files(dir: &str, retention_days: u64) {
+fn remove_old_log_files(dir: &Path, retention_days: u64) {
     let files = std::fs::read_dir(dir).unwrap();
 
     for file in files {

--- a/src/channels/single_file.rs
+++ b/src/channels/single_file.rs
@@ -2,7 +2,7 @@ use log::{LevelFilter, Log};
 use std::{
     fs::File,
     io::{LineWriter, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Mutex,
 };
 
@@ -21,7 +21,7 @@ pub struct SingleFileLogger {
 }
 
 impl SingleFileLogger {
-    pub fn new(path: &str, append: bool, config: Config) -> Result<Self, FtailError> {
+    pub fn new(path: &Path, append: bool, config: Config) -> Result<Self, FtailError> {
         let file = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
@@ -32,7 +32,7 @@ impl SingleFileLogger {
         let md = std::fs::metadata(path).map_err(FtailError::IoError)?;
 
         if md.permissions().readonly() {
-            return Err(FtailError::PermissionsError(path.to_string()));
+            return Err(FtailError::PermissionsError(path.to_owned()));
         }
 
         Ok(SingleFileLogger {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, path::PathBuf};
 
 use log::SetLoggerError;
 
@@ -7,7 +7,7 @@ pub enum FtailError {
     SetLoggerError(SetLoggerError),
     NoChannelsError,
     IoError(std::io::Error),
-    PermissionsError(String),
+    PermissionsError(PathBuf),
 }
 
 impl std::error::Error for FtailError {}
@@ -19,7 +19,7 @@ impl Display for FtailError {
             FtailError::NoChannelsError => write!(f, "No channels were added to the logger"),
             FtailError::IoError(e) => write!(f, "I/O error: {}", e),
             FtailError::PermissionsError(path) => {
-                write!(f, "The path {} is read-only", path)
+                write!(f, "The path {} is read-only", path.display())
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,8 @@
 //! 19:37:22.403 [ERROR] This is an error message
 //! ```
 
+use std::path::Path;
+
 use channels::{
     console::ConsoleLogger, daily_file::DailyFileLogger, formatted_console::FormattedConsoleLogger,
     single_file::SingleFileLogger,
@@ -319,8 +321,8 @@ impl Ftail {
     }
 
     /// Add a channel that logs messages to a single file.
-    pub fn single_file(self, path: &str, append: bool, level: log::LevelFilter) -> Self {
-        let path = path.to_string();
+    pub fn single_file(self, path: &Path, append: bool, level: log::LevelFilter) -> Self {
+        let path = path.to_owned();
 
         let constructor = move |config: Config| {
             Box::new(SingleFileLogger::new(&path, append, config).unwrap())
@@ -331,8 +333,8 @@ impl Ftail {
     }
 
     /// Add a channel that logs messages to a daily log file.
-    pub fn daily_file(self, path: &str, level: log::LevelFilter) -> Self {
-        let path = path.to_string();
+    pub fn daily_file(self, path: &Path, level: log::LevelFilter) -> Self {
+        let path = path.to_owned();
 
         let constructor = move |config: Config| {
             Box::new(DailyFileLogger::new(&path, config).unwrap()) as Box<dyn Log + Send + Sync>


### PR DESCRIPTION
Since Rust has specific types for file paths, the `Ftail::single_file()` and `Ftail::daily_file()` functions should take a value of type `&Path` instead of `&str`. This makes them more flexible, as there are valid paths which are not valid UTF-8 strings.


Further, if the user of the library already has a `&str`, converting to a `&Path` is zero-cost, whereas converting a `&Path` to a `&str` requires an $O(n)$ UTF-8 check.